### PR TITLE
Add #10 오류처리 (1), (2)

### DIFF
--- a/src/main/java/com/getinline/getinline/constant/ErrorCode.java
+++ b/src/main/java/com/getinline/getinline/constant/ErrorCode.java
@@ -13,24 +13,26 @@ public enum ErrorCode {
     OK(0, ErrorCategory.NORMAL, "Ok"),
 
     // 클라이언트에게 문제가 있었을 경우
-    BAD_REQUEST(10000, ErrorCategory.CLIENT_SIDE, "bad request"),
+    BAD_REQUEST(10000, ErrorCategory.CLIENT_SIDE, "Bad request"),
     SPRING_BAD_REQUEST(10001, ErrorCategory.CLIENT_SIDE, "Spring-detected bad request"),
     VALIDATION_ERROR(10002, ErrorCategory.CLIENT_SIDE, "Validation error"),
 
     // 서버에 문제가 있었을 경우
-    INTERNAL_ERROR(20000, ErrorCategory.SERVER_SIDE, "internal error"),
-    SPRING_INTERNAL_ERROR(20001, ErrorCategory.SERVER_SIDE, "Spring-detected internal error")
+    INTERNAL_ERROR(20000, ErrorCategory.SERVER_SIDE, "Internal error"),
+    SPRING_INTERNAL_ERROR(20001, ErrorCategory.SERVER_SIDE, "Spring-detected internal error"),
+    DATA_ACCESS_ERROR(20002, ErrorCategory.SERVER_SIDE, "Data access error")
     ;
 
     private final Integer code;
     private final ErrorCategory errorCategory;
     private final String message;
 
+    // 익셉션을 받을 경우
     public String getMessage(Exception e){
         return getMessage(this.getMessage() + " - " +e.getMessage());
     }
 
-    // message 받아서 비어있지 않다면 사용하고 아니라면 만들어뒀던것을 사용
+    // message 받아서 비어있지 않다면 사용하고 아니라면 만들어뒀던것을 사용(사용자 정의 메세지)
     public String getMessage(String message){
         return Optional.ofNullable(message)
                 .filter(Predicate.not(String::isBlank)) // => isBlank 공백이 아니라면

--- a/src/main/java/com/getinline/getinline/controller/api/APIEventController.java
+++ b/src/main/java/com/getinline/getinline/controller/api/APIEventController.java
@@ -17,6 +17,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
@@ -49,10 +50,10 @@ public class APIEventController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/events")
-    public APIDataResponse<String> createEvent(@RequestBody EventRequest eventRequest) {
+    public APIDataResponse<String> createEvent(@Valid @RequestBody EventRequest eventRequest) {
         boolean result = eventService.createEvent(eventRequest.toDTO());
 
-        return true;
+        return APIDataResponse.of(Boolean.toString(result));
     }
 
     @GetMapping("/events/{eventId}")

--- a/src/main/java/com/getinline/getinline/dto/EventRequest.java
+++ b/src/main/java/com/getinline/getinline/dto/EventRequest.java
@@ -6,6 +6,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
 import java.time.LocalDateTime;
 
 @Getter
@@ -14,16 +18,45 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class EventRequest {
 
+    @NotNull
+    @Positive
     private Long placeId;
+
+    @NotBlank
     private String eventName;
+
+    @NotNull
     private EventStatus eventStatus;
+
+    @NotNull
     private LocalDateTime eventStartDatetime;
+
+    @NotNull
     private LocalDateTime eventEndDatetime;
+
+    @NotNull
+    @PositiveOrZero
     private Integer currentNumberOfPeople;
+
+    @NotNull
+    @Positive
     private Integer capacity;
+
     private String memo;
-    private LocalDateTime createdAt;
-    private LocalDateTime modifiedAt;
+
+
+    public static EventRequest of(EventDTO event){
+        return EventRequest.builder()
+                .placeId(event.getPlaceId())
+                .eventName(event.getEventName())
+                .eventStatus(event.getEventStatus())
+                .eventStartDatetime(event.getEventStartDatetime())
+                .eventEndDatetime(event.getEventEndDatetime())
+                .currentNumberOfPeople(event.getCurrentNumberOfPeople())
+                .capacity(event.getCapacity())
+                .memo(event.getMemo())
+                .build();
+    }
 
     public EventDTO toDTO(){
         return EventDTO.builder()
@@ -35,8 +68,6 @@ public class EventRequest {
                 .currentNumberOfPeople(this.currentNumberOfPeople)
                 .capacity(this.capacity)
                 .memo(this.memo)
-                .createdAt(this.createdAt)
-                .modifiedAt(this.modifiedAt)
                 .build();
     }
 

--- a/src/main/java/com/getinline/getinline/service/EventService.java
+++ b/src/main/java/com/getinline/getinline/service/EventService.java
@@ -1,7 +1,9 @@
 package com.getinline.getinline.service;
 
+import com.getinline.getinline.constant.ErrorCode;
 import com.getinline.getinline.constant.EventStatus;
 import com.getinline.getinline.dto.EventDTO;
+import com.getinline.getinline.exception.GeneralException;
 import com.getinline.getinline.repository.EventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,7 +26,14 @@ public class EventService {
             LocalDateTime eventStartDateTime,
             LocalDateTime eventEndDateTime
     ){
-        return eventRepository.findEvents(placeId, eventName, eventStatus, eventStartDateTime, eventEndDateTime);
+        try {
+            return eventRepository.findEvents(
+                    placeId, eventName, eventStatus, eventStartDateTime, eventEndDateTime
+            );
+        }
+        catch (Exception e){
+            throw new GeneralException(ErrorCode.DATA_ACCESS_ERROR);
+        }
     }
 
     public Optional<EventDTO> getEvent(Long eventId){

--- a/src/test/java/com/getinline/getinline/constant/ErrorCodeTest.java
+++ b/src/test/java/com/getinline/getinline/constant/ErrorCodeTest.java
@@ -1,0 +1,84 @@
+package com.getinline.getinline.constant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class ErrorCodeTest {
+
+    @ParameterizedTest(name = "[{index}] {0} ===> {1}")
+    @MethodSource
+    @DisplayName("예외를 받으면, 예외 메시지가 포함된 메시지 출력")
+    void givenExceptionWithMessage_whenGettingMessage_thenReturnsMessage(ErrorCode sut, String expected) {
+        // Given
+        Exception e = new Exception("This is test message.");
+
+        // When
+        String result = sut.getMessage(e);
+
+        // Then
+        System.out.println(result);
+        assertThat(result).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> givenExceptionWithMessage_whenGettingMessage_thenReturnsMessage(){
+        return Stream.of(
+                arguments(ErrorCode.OK, "Ok - This is test message."),
+                arguments(ErrorCode.BAD_REQUEST, "Bad request - This is test message."),
+                arguments(ErrorCode.SPRING_BAD_REQUEST, "Spring-detected bad request - This is test message."),
+                arguments(ErrorCode.VALIDATION_ERROR, "Validation error - This is test message."),
+                arguments(ErrorCode.INTERNAL_ERROR, "Internal error - This is test message."),
+                arguments(ErrorCode.SPRING_INTERNAL_ERROR, "Spring-detected internal error - This is test message."),
+                arguments(ErrorCode.DATA_ACCESS_ERROR, "Data access error - This is test message.")
+        );
+    }
+
+    @ParameterizedTest(name = "[{index}] \"{0}\" ===> {1}")
+    @MethodSource
+    @DisplayName("에러 메세지를 받으면, 해당 애러 메세지로 출력")
+    void givenMessage_whenGettingMessage_thenReturnsMessage(String input, String expected) {
+        // Given
+
+        // When
+        String result = ErrorCode.INTERNAL_ERROR.getMessage(input);
+
+        // Then
+        System.out.println(result);
+        assertThat(result).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> givenMessage_whenGettingMessage_thenReturnsMessage(){
+        return Stream.of(
+                arguments(null, ErrorCode.INTERNAL_ERROR.getMessage()),
+                arguments("", ErrorCode.INTERNAL_ERROR.getMessage()),
+                arguments("   ", ErrorCode.INTERNAL_ERROR.getMessage()),
+                arguments("This is test message.", "This is test message.")
+
+        );
+    }
+
+    @DisplayName("toString() 호출 포맷")
+    @Test
+    void givenErrorCode_whenToString_thenReturnsSimplifiedToString(){
+        // Given
+
+
+        // When
+        String result = ErrorCode.INTERNAL_ERROR.toString();
+
+        // Then
+        System.out.println(result);
+        assertThat(result).isEqualTo("INTERNAL_ERROR (20000)");
+    }
+
+
+
+}

--- a/src/test/java/com/getinline/getinline/controller/api/APIEventControllerTest.java
+++ b/src/test/java/com/getinline/getinline/controller/api/APIEventControllerTest.java
@@ -5,6 +5,7 @@ import com.getinline.getinline.constant.ErrorCode;
 import com.getinline.getinline.constant.EventStatus;
 import com.getinline.getinline.constant.PlaceType;
 import com.getinline.getinline.dto.EventDTO;
+import com.getinline.getinline.dto.EventResponse;
 import com.getinline.getinline.service.EventService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
@@ -114,7 +116,40 @@ class APIEventControllerTest {
                 .andExpect(jsonPath("$.message").value(containsString(ErrorCode.VALIDATION_ERROR.getMessage())));
         then(eventService).shouldHaveNoInteractions();
     }
+    
+    @DisplayName("[API] [POST] 이벤트 생성 - 잘못된 데이터 입력")
+    @Test
+    void givenWrongEvent_whenCreatingAnEvent_thenReturnsFailedStandardResponse() throws Exception{
+        // Given
+        EventResponse eventResponse = EventResponse.of(
+                EventDTO.builder()
+                        .placeId(-1L)
+                        .eventName("   ")
+                        .eventStatus(null)
+                        .eventStartDatetime(null)
+                        .eventEndDatetime(null)
+                        .currentNumberOfPeople(-1)
+                        .capacity(0)
+                        .memo("마스크 꼭 착용하세요")
+                        .build()
+        );
 
+        
+        // When & Then
+        mvc.perform(
+                        post("/api/events")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(mapper.writeValueAsString(eventResponse))
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.VALIDATION_ERROR.getCode()))
+                .andExpect(jsonPath("$.message").value(containsString(ErrorCode.VALIDATION_ERROR.getMessage())));
+        then(eventService).shouldHaveNoInteractions();
+        
+    }
+    
     private EventDTO createEventDTO(
     ){
         return EventDTO.builder()

--- a/src/test/java/com/getinline/getinline/error/APIExceptionHandlerTest.java
+++ b/src/test/java/com/getinline/getinline/error/APIExceptionHandlerTest.java
@@ -1,0 +1,96 @@
+package com.getinline.getinline.error;
+
+import com.getinline.getinline.constant.ErrorCode;
+import com.getinline.getinline.dto.APIErrorResponse;
+import com.getinline.getinline.exception.GeneralException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.handler.DispatcherServletWebRequest;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.ConstraintViolationException;
+
+import java.util.Set;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class APIExceptionHandlerTest {
+
+    private APIExceptionHandler sut;
+    private WebRequest webRequest;
+
+    @BeforeEach
+    void setUp() {
+        sut = new APIExceptionHandler();
+        webRequest = new DispatcherServletWebRequest(new MockHttpServletRequest());
+    }
+
+    @DisplayName("검증 오류 - 응답 데이터 정의")
+    @Test
+    void givenValidationException_whenCallingValidation_thenReturnsResponseEntity(){
+        // Given
+        ConstraintViolationException e = new ConstraintViolationException(Set.of());
+
+        // When
+        ResponseEntity<Object> response = sut.validation(e, webRequest);
+
+        // Then
+        System.out.println(response.getBody());
+        System.out.println(response.getHeaders());
+        System.out.println(response.getStatusCode());
+        assertThat(response)
+                .hasFieldOrPropertyWithValue("body", APIErrorResponse.of(false, ErrorCode.VALIDATION_ERROR, e))
+                .hasFieldOrPropertyWithValue("headers", HttpHeaders.EMPTY)
+                .hasFieldOrPropertyWithValue("statusCode", HttpStatus.BAD_REQUEST);
+
+    }
+
+    @DisplayName("프로젝트 일반 오류 - 응답 데이터 정의")
+    @Test
+    void givenGeneralException_whenCallingValidation_thenReturnsResponseEntity(){
+        // Given
+        ErrorCode errorCode = ErrorCode.INTERNAL_ERROR;
+        GeneralException e = new GeneralException(errorCode);
+
+        // When
+        ResponseEntity<Object> response = sut.general(e, webRequest);
+
+        // Then
+        System.out.println(response.getBody());
+        System.out.println(response.getHeaders());
+        System.out.println(response.getStatusCode());
+        assertThat(response)
+                .hasFieldOrPropertyWithValue("body", APIErrorResponse.of(false, errorCode, e))
+                .hasFieldOrPropertyWithValue("headers", HttpHeaders.EMPTY)
+                .hasFieldOrPropertyWithValue("statusCode", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    }
+
+    @DisplayName("기타(전체) 오류 - 응답 데이터 정의")
+    @Test
+    void givenOtherException_whenCallingValidation_thenReturnsResponseEntity(){
+        // Given
+        Exception e = new Exception();
+
+        // When
+        ResponseEntity<Object> response = sut.exception(e, webRequest);
+
+        // Then
+        System.out.println(response.getBody());
+        System.out.println(response.getHeaders());
+        System.out.println(response.getStatusCode());
+        assertThat(response)
+                .hasFieldOrPropertyWithValue("body", APIErrorResponse.of(false, ErrorCode.INTERNAL_ERROR, e))
+                .hasFieldOrPropertyWithValue("headers", HttpHeaders.EMPTY)
+                .hasFieldOrPropertyWithValue("statusCode", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    }
+
+}

--- a/src/test/text/비즈니스 로직 구현 ch3/03.오류 처리 (1), (2)
+++ b/src/test/text/비즈니스 로직 구현 ch3/03.오류 처리 (1), (2)
@@ -1,0 +1,240 @@
+* 서비스 로직 오류처리
+
+    TODO
+        - 에러 코드 테스트
+        - 예외 처리 로직 입출력 테스트
+        - 서비스 로직에 유의미한 에러 처리를 추가해보기
+
+* 에러 코드 테스트
+
+    - 아래와 같이 테스트코드를 짠다면 에러코드 OK 에 대한 테스트코드일 뿐이고
+      그 아래에 다른 테스트코드들을 추가한다면 6~10개 많은 반복코드가 추가될것이다.
+      그래서 이것을 더 유용하게 하기위한 다른 테스트 기법이 있다.
+      ParameterizedTest 기법이라 한다.
+
+    @Test
+    @DisplayName("예외를 받으면, 예외 메시지가 포함된 메시지 출력")
+        void givenExceptionWithMessage_whenGettingMessage_thenReturnsMessage() {
+            // Given
+            Exception e = new Exception("This is test message.");
+
+            // When
+            String result = ErrorCode.OK.getMessage(e);
+
+            // Then
+            assertThat(result).isEqualTo("Ok - This is test message.");
+        }
+
+
+    - ParameterizedTest
+      최근의 모던한 프레임워크는 모두 지원하고 있고
+      Junit4 부터 지원했다. Junit5 는 좀 더 정돈된 방법으로 지원한다.
+      @MethodSource => 입력 소스로 메소드를 받을 수 있다. 이 외에도 몇가지 소스를 받는 방법들이 있다.
+      메서드는 이름이 같아야한다. @MethodSource("이름지정가능") 다음과 같이 메서드 이름도 지정이 가능하다.
+      그러나 이름을 똑같이하는게 찾기와 보기가 쉽다.
+
+      아래와 같이 테스트시 출력되는 모양을 꾸며줄 수 도 있다.
+      @ParameterizedTest(name = "[{index}] {0} ===> {1}")
+
+      @ParameterizedTest
+          @MethodSource
+          @DisplayName("예외를 받으면, 예외 메시지가 포함된 메시지 출력")
+          void givenExceptionWithMessage_whenGettingMessage_thenReturnsMessage(ErrorCode sut, String expected) {
+              // Given
+              Exception e = new Exception("This is test message.");
+
+              // When
+              String result = sut.getMessage(e);
+
+              // Then
+              assertThat(result).isEqualTo(expected);
+          }
+
+          static Stream<Arguments> givenExceptionWithMessage_whenGettingMessage_thenReturnsMessage(){
+              return Stream.of(
+                      arguments(ErrorCode.OK, "Ok - This is test message."),
+                      arguments(ErrorCode.BAD_REQUEST, "Bad request - This is test message."),
+                      arguments(ErrorCode.SPRING_BAD_REQUEST, "Spring-detected bad request - This is test message."),
+                      arguments(ErrorCode.VALIDATION_ERROR, "Validation error - This is test message."),
+                      arguments(ErrorCode.INTERNAL_ERROR, "Internal error - This is test message."),
+                      arguments(ErrorCode.SPRING_INTERNAL_ERROR, "Spring-detected internal error - This is test message.")
+              );
+          }
+
+
+    - 아래는 애러메세지를 직접 입력받았을떄의 테스트이다.
+
+        @ParameterizedTest(name = "[{index}] \"{0}\" ===> {1}")
+            @MethodSource
+            @DisplayName("에러 메세지를 받으면, 해당 애러 메세지로 출력")
+            void givenMessage_whenGettingMessage_thenReturnsMessage(String input, String expected) {
+                // Given
+
+                // When
+                String result = ErrorCode.INTERNAL_ERROR.getMessage(input);
+
+                // Then
+                assertThat(result).isEqualTo(expected);
+            }
+
+            static Stream<Arguments> givenMessage_whenGettingMessage_thenReturnsMessage(){
+                return Stream.of(
+                        arguments(null, ErrorCode.INTERNAL_ERROR.getMessage()),
+                        arguments("", ErrorCode.INTERNAL_ERROR.getMessage()),
+                        arguments("   ", ErrorCode.INTERNAL_ERROR.getMessage()),
+                        arguments("This is test message.", "This is test message.")
+
+                );
+            }
+
+
+    - 아래는 ToString 으로 에러를 어떻게 보여줄지 테스트하는 방법이다.
+     @DisplayName("toString() 호출 포맷")
+        @Test
+        void givenErrorCode_whenToString_thenReturnsSimplifiedToString(){
+            // Given
+
+
+            // When
+            String result = ErrorCode.INTERNAL_ERROR.toString();
+
+            // Then
+            assertThat(result).isEqualTo("INTERNAL_ERROR (20000)");
+        }
+
+
+
+
+* 예외 처리 로직 입출력 테스트
+
+    WebRequest 를 인자로 받고있는 모습을 볼 수 있다. 그러나 테스트에서는
+    request 가 주요 관심사는 아니기에 Mock 으로 대체한다.
+    public ResponseEntity<Object> general(ConstraintViolationException e, WebRequest request){ ... }
+
+    // 검증시 나오는 오류에 대한 바디, 해더, 상태코드의 형식을 원하는 대로 나오는지 테스트해본다.
+    @DisplayName("검증 오류 - 응답 데이터 정의")
+        @Test
+        void givenValidationException_whenCallingValidation_thenReturnsResponseEntity(){
+            // Given
+            ConstraintViolationException e = new ConstraintViolationException(Set.of());
+
+            // When
+            ResponseEntity<Object> response = sut.validation(e, webRequest);
+
+            // Then
+            System.out.println(response.getBody());
+            System.out.println(response.getHeaders());
+            System.out.println(response.getStatusCode());
+            assertThat(response)
+                    .hasFieldOrPropertyWithValue("body", APIErrorResponse.of(false, ErrorCode.VALIDATION_ERROR, e))
+                    .hasFieldOrPropertyWithValue("headers", HttpHeaders.EMPTY)
+                    .hasFieldOrPropertyWithValue("statusCode", HttpStatus.BAD_REQUEST);
+
+        }
+
+    // 프로젝트에서 사용할 GeneralException 일반적인 오류사항들이 원하는 대로 나오는지 테스트해본다.
+    @DisplayName("프로젝트 일반 오류 - 응답 데이터 정의")
+        @Test
+        void givenGeneralException_whenCallingValidation_thenReturnsResponseEntity(){
+            // Given
+            ErrorCode errorCode = ErrorCode.INTERNAL_ERROR;
+            GeneralException e = new GeneralException(errorCode);
+
+            // When
+            ResponseEntity<Object> response = sut.general(e, webRequest);
+
+            // Then
+            System.out.println(response.getBody());
+            System.out.println(response.getHeaders());
+            System.out.println(response.getStatusCode());
+            assertThat(response)
+                    .hasFieldOrPropertyWithValue("body", APIErrorResponse.of(false, errorCode, e))
+                    .hasFieldOrPropertyWithValue("headers", HttpHeaders.EMPTY)
+                    .hasFieldOrPropertyWithValue("statusCode", HttpStatus.INTERNAL_SERVER_ERROR);
+
+        }
+
+    // 잡아내지 못한 오류사항들
+    @DisplayName("기타(전체) 오류 - 응답 데이터 정의")
+        @Test
+        void givenOtherException_whenCallingValidation_thenReturnsResponseEntity(){
+            // Given
+            Exception e = new Exception();
+
+            // When
+            ResponseEntity<Object> response = sut.exception(e, webRequest);
+
+            // Then
+            System.out.println(response.getBody());
+            System.out.println(response.getHeaders());
+            System.out.println(response.getStatusCode());
+            assertThat(response)
+                    .hasFieldOrPropertyWithValue("body", APIErrorResponse.of(false, ErrorCode.INTERNAL_ERROR, e))
+                    .hasFieldOrPropertyWithValue("headers", HttpHeaders.EMPTY)
+                    .hasFieldOrPropertyWithValue("statusCode", HttpStatus.INTERNAL_SERVER_ERROR);
+
+        }
+
+
+
+* 리펙토링
+
+    APIExceptionHandler 클래스에 다음과 같은 코드가 계속 반복된다.
+    이걸 메서드로 추출해보자. Ctrl + Shift + A => Extract Method... 클릭
+    위의 커멘드키 입력시 자동으로 메서드를 생성해준다.
+
+    return super.handleExceptionInternal(
+                    e,
+                    APIErrorResponse.of(false, errorCode.getCode(), errorCode.getMessage(e)),
+                    HttpHeaders.EMPTY,
+                    status,
+                    request
+            );
+
+
+
+* 서비스 로직에 유의미한 에러 처리를 추가해보기
+
+    많은 에러들이 있고 Service 로직에서는 예상치 못한 오류들이 발생할 수 있다.
+    데이터베이스에서 날수도있고, JPA 에서도 발생할 수 있다. Exception 처리를 해뒀기에
+    500에러로 처리가 되겠지만, 발생되는 예상치 못한 모든오류들을
+    500Error 로 처리하면 에러처리를 하는 의미가 없다.
+    그런 오류들을 잡아서 의미있는 애러로 내보내보자.
+
+     @DisplayName("이벤트를 검색하는데 애러가 발생한 경우, 줄서기 프로젝트 기본 에러로 전환하여 예외를 던진다.")
+        @Test
+        void givenDataRelatedException_whenSearchingEvents_thenThrowsGeneralException(){
+            // Given
+            RuntimeException e = new RuntimeException("This is test.");
+            given(eventRepository.findEvents(any(), any(), any(), any(), any()))
+                    .willThrow(e);
+
+            // When
+            Throwable thrown = catchThrowable(() -> sut.getEvents(null,null,null,null,null));
+
+            // Then
+            assertThat(thrown)
+                    .isInstanceOf(GeneralException.class)
+                    .hasMessageContaining(ErrorCode.DATA_ACCESS_ERROR.getMessage());
+            then(eventRepository).should().findEvents(null,null,null,null,null);
+        }
+
+     우리가 아는 애러메세지로 전환해서 내보냈다. return 시에 try, catch 로 감싸서
+     구체적으로 에러를 명시해주었다.
+
+     public List<EventDTO> getEvents(
+                 Long placeId,
+                 String eventName,
+                 EventStatus eventStatus,
+                 LocalDateTime eventStartDateTime,
+                 LocalDateTime eventEndDateTime
+         ){
+             try {
+                 return eventRepository.findEvents(
+                         placeId, eventName, eventStatus, eventStartDateTime, eventEndDateTime
+                 );
+             }
+             catch (Exception e){
+                 throw new GeneralException(ErrorCode.DATA_ACCESS_ERROR);
+             }
+         }


### PR DESCRIPTION
- 에러 코드를 테스트하고
- 예외 처리 로직에 대해 입출력 테스트를 하고
- 서비스 로직에 유의미한 에러처리를 추가해보았다.

서비스 로직의 유의미한 에러처리란. JPA 혹은 db 에서 나는 애러까지 포함한 것들이다. 우리는 이렇게 알수없는 오류를 Exception 으로 기본 애러 즉, 500애러를 던져주는것으로 마무리했지만 이렇게 500애러만 계속 던져주는것은 애러처리를 잘 하지 못했다는것이 된다.

이렇게 예외처리를 많이하니 아직은 익숙하지 않아 복잡해보인다. 모든 예외를 처리할 수는 없겠지만 적당한 선까지 하는게 좋은걸까? 아니면 최대한 예외를 잡을수 있는데까지 잡는게 좋은걸까. 
내 생각에는 최대한 잡는것이 좋을것 같다. 그래야 개발자가 빠르게 에러의 원인을 캐치할 수 있기 때문이다. 오류시 디버깅하는 시간을 조금 줄일수있을것 같다.