### PR TITLE
Add #23 DataSource, TransactionManager

### DIFF
--- a/src/main/java/com/getinline/getinline/config/JpaConfig.java
+++ b/src/main/java/com/getinline/getinline/config/JpaConfig.java
@@ -1,9 +1,93 @@
 package com.getinline.getinline.config;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionSynchronization;
+
+import javax.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
 
 @EnableJpaAuditing
 @Configuration
 public class JpaConfig {
+
+    // 직접 DataSource 를 설정하고 싶을때.
+    //spring.datasource.url=jdbc:h2:mem:testdb properties 에 있는 이 내용이 주입된다.
+//    @Bean
+//    @ConfigurationProperties("spring.datasource")
+//    public DataSource dataSource() {
+//        return DataSourceBuilder.create().build();
+//    }
+//
+//    @Bean
+//    @ConfigurationProperties("spring.datasource")
+//    public DataSource dataSource2() {
+//        return DataSourceBuilder.create().build();
+//    }
+//
+//    @Bean
+//    public LocalContainerEntityManagerFactoryBean entityManagerFactory(DataSource dataSource) {
+//
+//        HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+//        vendorAdapter.setGenerateDdl(true);
+//
+//        LocalContainerEntityManagerFactoryBean factory = new LocalContainerEntityManagerFactoryBean();
+//        factory.setJpaVendorAdapter(vendorAdapter);
+//        factory.setPackagesToScan("com.getinline.getinline");
+//        factory.setDataSource(dataSource);
+//        return factory;
+//    }
+//
+//    @Bean
+//    public LocalContainerEntityManagerFactoryBean entityManagerFactory2(DataSource dataSource2) {
+//
+//        HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+//        vendorAdapter.setGenerateDdl(true);
+//
+//        LocalContainerEntityManagerFactoryBean factory = new LocalContainerEntityManagerFactoryBean();
+//        factory.setJpaVendorAdapter(vendorAdapter);
+//        factory.setPackagesToScan("com.getinline.getinline");
+//        factory.setDataSource(dataSource2);
+//        return factory;
+//    }
+//
+//    @Bean
+//    public PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
+//        JpaTransactionManager txManager = new JpaTransactionManager();
+//        txManager.setEntityManagerFactory(entityManagerFactory);
+//        return txManager;
+//    }
+//
+//    @Bean
+//    public PlatformTransactionManager transactionManager2(EntityManagerFactory entityManagerFactory2) {
+//        JpaTransactionManager txManager = new JpaTransactionManager();
+//        txManager.setEntityManagerFactory(entityManagerFactory2);
+//        return txManager;
+//    }
+
+    // db 가 2개일때의 문제
+    /*
+        db 를 2개를 사용한다면 1번 db 에서 문제가 생기면 2번째 db 는 롤백이 자동으로 된다.
+        그러나 1번쨰것이 커밋이 되고 2번째가 문제가 생긴다면? 원자성이 지켜지지않는다.
+        그래서 직접 관리할 수 있도록 설정을 따로 하게되었다.
+     */
+
+
+    // Transaction 관리를 해야하는데 만약 2개의 데이터베이스를 동시에 사용하고있다면 어떻게 해야할까?
+    // 기존에 사용하던 방법은 사라짐. TransactionSynchronization 가 최신버전이고 이걸 사용할 준비를 해야한다.
+//    @Bean
+//    public TransactionSynchronization transactionSynchronization(
+//
+//    ){
+//
+//    }
 }

--- a/src/main/java/com/getinline/getinline/service/EventService.java
+++ b/src/main/java/com/getinline/getinline/service/EventService.java
@@ -8,6 +8,7 @@ import com.getinline.getinline.repository.EventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -33,6 +34,7 @@ public class EventService {
         }
     }
 
+    @Transactional(readOnly = true)
     public List<EventDTO> getEvents(
             Long placeId,
             String eventName,
@@ -47,6 +49,7 @@ public class EventService {
         }
     }
 
+    @Transactional(readOnly = true)
     public Optional<EventDTO> getEvent(Long eventId) {
         try {
             return eventRepository.findById(eventId).map(EventDTO::of);
@@ -55,6 +58,7 @@ public class EventService {
         }
     }
 
+    @Transactional(readOnly = true)
     public boolean createEvent(EventDTO eventDTO) {
         try {
             if (eventDTO == null) {
@@ -68,6 +72,7 @@ public class EventService {
         }
     }
 
+    @Transactional(readOnly = true)
     public boolean modifyEvent(Long eventId, EventDTO dto) {
         try {
             if (eventId == null || dto == null) {
@@ -83,6 +88,7 @@ public class EventService {
         }
     }
 
+    @Transactional(readOnly = true)
     public boolean removeEvent(Long eventId) {
         try {
             if (eventId == null) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,7 +23,7 @@ spring.datasource.url=jdbc:h2:mem:testdb
 
 # API
 spring.data.rest.base-path=/api
-spring.data.rest.detection-strategy=annotated
+#spring.data.rest.detection-strategy=annotated
 
 server.error.whitelabel.enabled=true
 

--- a/src/test/text/Part4. Spring Data JPA/SpringDataJpa와 테크닉 ch2/03.DataSource, TransactionManager
+++ b/src/test/text/Part4. Spring Data JPA/SpringDataJpa와 테크닉 ch2/03.DataSource, TransactionManager
@@ -1,0 +1,106 @@
+* DataSource, TransactionManager
+
+    - DataSource
+      물리적인 데이터소스(데이터베이스) 정보를 담는 인터페이스
+        - 하나의 물리 데이터베이스를 표현
+        - 다양한 구현체를 사용
+            - EmbeddedDatabaseBuilder: HSQL, Derby, H2 등 임베디드 DB 세팅할 때 사용
+            - DataSourceBuilder: JDBC DataSource 빌더
+            - DriverManagerDataSource: JDBC 드라이버로 세팅하는 DataSource
+            - SimpleDriverDataSource: DriverManagerDataSource 를 간편하게 만든 버전
+            - HikariDataSource: HikariCP 를 connection pool 로 사용하는 DataSource
+            - 기타 등등
+
+
+    - TransactionManager
+      스프링 트랜잭션 관리 기능을 담당하는 인터페이스
+          - 용도에 따라 다양한 인터페이스와 구현체들
+          - PlatformTransactionManager, ReactiveTransactionManager
+          - JpaTransactionManager: Spring Data JPA 일반적인 상황에 사용하는 구현체, 단일
+            EntityManagerFactory 를 사용
+          - DataSourceTransactionManager: 단일 JDBC DataSource 를 사용하는 구현체
+          - HibernateTransactionManager: 하이버네이트 SessionFactory 를 사용하는 구현체
+          - ChainedTransactionManager: 여러 개의 트랜잭션 매니저를 묶어서 사용하는 구현체
+                1.@Deprecated !!! (as of Boot 2.5) 트랜잭션 매니저를 묶어서 사용하는것이 사라졌다.
+          - 등등
+
+
+    - JPA DB 수동설정(Java code)
+      자바 코드로 DataSource, TransactionManager 를 수동 세팅해야 하는 경우가 있다.
+      - 언제?
+            1.configuration properties 로 커버되지 않는 세밀한 옵션을 줄 때
+            2.다중 DataSource
+      - 세팅해야 하는 요소
+            1.DataSource
+            2.EntityManagerFactory -> LocalContainerEntityManagerFactoryBean
+                - 추가적인 예외 처리 기능 때문에, 인터페이스 말고 구현체를 직접 빈으로 등록해야 한다!
+            3.PlatformTransactionManager
+      - 세팅 구성: DataSource (DB 설정) -> EntityManagerFactory(JPA 엔티티 관리) ->
+        PlatformTransactionManager (트랜잭션 관리)
+
+
+    - @Transactional
+      스프링이 애노테이션 기반 트랜잭션 관리 기능을 제공
+          - EntityManager 불러오고 -> 구역 지정하고 -> commit(), rollback() 직접 할 필요 없다!
+          - 서비스 클래스, 메소드에 적용하는 것으로 간단히 트랜잭션 구역을 설정
+          - 동시에 설정하면 메소드가 우선순위
+          - JpaRepository 는 메소드 단위 @Transactional 이 이미 붙어있음
+          - 관련 애노테이션
+          - 스프링 테스트 지원 애노테이션: @DataJpaTest 와 좋은 궁합
+          - @Commit
+          - @Rollback
+          - javax.transaction.@Transactional: 스프링 패키지가 아님, 기대하는 기능을 주지 않으므로 주의
+
+
+    - @Transactional: attributes
+      @Transactional 이 제공하는 다양한 옵션들
+      - transactionManager(value): 사용할 트랜잭션 매니저를 이름으로 특정
+      - label: 트랜잭션 구분 짓고 식별하는 레이블
+      - propagation: 트랜잭션이 중첩될 경우 동작(트랜잭션 효과의 전파) 규칙 (default: REQUIRED)
+
+            *propagation!!!
+              springBoot 관련 단골 면접질문중 하나 = 트랜잭션이 repository 에도 있고 service 에도 있다면?
+              트랜잭션이 여러개 사용되어 중첩되는 경우는 어떻게 되는것인가?
+              이런때에는 규칙을 정해줄수가 있다. 이런것을 트랜잭션을 전파시킨다고 한다.
+              기본값은 Required 이다.(자세히 꼭 공부하자)
+
+      - isolation: 트랜잭션 내부 데이터의 격리 레벨 (default: DEFAULT)
+      - timeout, timeoutString: 시간 제한을 거는 것이 가능
+      - readOnly: "이 트랜잭션 안에서는 select 만 일어난다" 를 표현
+            1.강제성이 없음을 주의 - 힌트로 생각하자
+            2.이 옵션을 처리하지 않는 트랜잭션 매니저 구현체를 사용할 경우, 별도의 예외처리를 안 함
+      - rollbackFor, rollbackForClassName
+      - noRollbackFor, noRollbackForClassNam
+
+    *.중요!!!!! 면접시 단골 질문이라고 한다.
+    *propagation!!!
+                  springBoot 관련 단골 면접질문중 하나 = 트랜잭션이 repository 에도 있고 service 에도 있다면?
+                  트랜잭션이 여러개 사용되어 중첩되는 경우는 어떻게 되는것인가?
+                  이런때에는 규칙을 정해줄수가 있다. 이런것을 트랜잭션을 전파시킨다고 한다.
+                  기본값은 Required 이다.(자세히 꼭 공부하자)
+
+      @Transactional: Propagation
+                      중첩된 트랜잭션 동작 규칙칙
+                      - REQUIRED(default): 현재 있으면 보조, 없으면 새로 만들기
+                      - SUPPORTS: 현재 있으면 보조, 없으면 트랜잭션 없이 실행
+                      - MANDATORY: 있으면 보조, 없으면 예외 처리
+                      - REQUIRES_NEW: 트랜잭션 생성하고 실행, 현재 있던 것은 미룸
+                      - NOT_SUPPORTED: 트랜잭션 없이 실행, 현재 있던 것은 미룸
+                      - NEVER: 트랜잭션 없이 실행, 현재 트랜잭션이 있었으면 예외 처리
+                      - NESTED: 현재 있으면 그 안에서 중첩된 트랜잭션 형성
+
+
+    - @Transactional: Isolation
+      트랜잭션 내부 데이터의 격리 수준
+          - DEFAULT: 데이버테이스에게 맡김
+          - READ_UNCOMMITTED: dirty read + non-repeatable read + phantom read
+          - READ_COMMITTED: non-repeatable read + phantom read
+          - REPEATABLE_READ: phantom read
+          - SERIALIZABLE: 완전 직렬 수행
+
+
+    - 래퍼런스
+        • https://docs.spring.io/spring-data/jpa/docs/2.5.5/reference/html/#jpa.java-config
+        • https://github.com/spring-projects/spring-data-commons/issues/2232
+
+


### PR DESCRIPTION
- JPA DB 수동설정
- propagation (트랜잭션이 service 에도 설정이되어있고 repository 에도 있을 경우에는 어떻게 되는가? 이럴때에는 규칙을 정해줄수가있고 기본적으로 REQUIRED 가 디폴드값이다. 있으면 보조 없으면 새로 만들어준다.)

- db 를 2개 사용한다면? 1번 db 가 문제가 생겨 2번db 작업전 롤백이되면 원자성이 지켜지지만 1번db는 문제없이 커밋되고 2번db 가 롤백이된다면 원자성이 지켜지지않는다.!!!