### PR TITLE
#27 복잡한 쿼리의 작성과 응용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ bin/
 ### querydsl
 /src/main/generated
 
+### jooq
+/src/main/generated-jooq
+
 ### IntelliJ IDEA ###
 .idea
 *.iws

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@
 plugins {
     id 'org.springframework.boot' version '2.7.1'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-    id 'nu.studer.jooq' version '5.2.2' //6.0.1 은 jooq 버전이 3.15.1 스프링부트에서 자동관리해주는 버전보다 높다.
+//    id 'nu.studer.jooq' version '5.2.2' //6.0.1 은 jooq 버전이 3.15.1 스프링부트에서 자동관리해주는 버전보다 높다.
     id 'java'
     id 'war'
 }
@@ -32,7 +32,7 @@ repositories {
 
 project.ext {
     querydslVersion = dependencyManagement.importedProperties['querydsl.version']
-    jooqVersion = dependencyManagement.importedProperties['jooq.version']
+//    jooqVersion = dependencyManagement.importedProperties['jooq.version']
     mysqlVersion = dependencyManagement.importedProperties['mysql.version']
 }
 
@@ -65,8 +65,8 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api" // java.lang.NoClassDefFoundError (javax.annotation.Generated) 발생 대응
 
     // Jooq 설정 https://start.spring.io/
-    implementation 'org.springframework.boot:spring-boot-starter-jooq'
-    jooqGenerator "mysql:mysql-connector-java:${project.mysqlVersion}"
+//    implementation 'org.springframework.boot:spring-boot-starter-jooq'
+//    jooqGenerator "mysql:mysql-connector-java:${project.mysqlVersion}"
 }
 
 tasks.named('test') {
@@ -99,64 +99,69 @@ tasks.withType(JavaCompile) {
 //}
 
 
-def generatedJooq = 'src/main/generated-jooq'
-jooq {
-    // use jOOQ version defined in Spring Boot
-//    version = dependencyManagement.importedProperties['jooq.version']
-    version = project.jooqVersion
-
-    configurations {
-        main {
-            generationTool {
-                logging = org.jooq.meta.jaxb.Logging.WARN
-                jdbc {
-                    driver = 'com.mysql.cj.jdbc.Driver'
-                    url = 'jdbc:mysql://172.17.47.198:3306/mygetinline?useSSL=false&allowPublicKeyRetrieval=true'
-                    user = 'strou73'
-                    password = '1234'
-                }
-                generator {
-                    name = 'org.jooq.codegen.JavaGenerator'
-                    database{
-                        name = 'org.jooq.meta.mysql.MySQLDatabase'
-                        inputSchema = 'mygetinline'
-                        includes = '.*'
-                        excludes = ''
-                        forcedTypes {
-                            forcedType {
-                                userType = 'com.getinline.getinline.constant.EventStatus'
-                                enumConverter = true
-                                includeExpression = '.*\\.event_status'
-                                includeTypes = '.*'
-                            }
-                            forcedType {
-                                userType = 'com.getinline.getinline.constant.PlaceType'
-                                enumConverter = true
-                                includeExpression = '.*\\.place_type'
-                                includeTypes = '.*'
-                            }
-                        }
-                    }
-                    generate {
-                        deprecated = false
-                        records = true
-                        immutablePojos = true
-                        fluentSetters = true
-                        javaTimeTypes = true // LocalDateTime 을 자동으로 컨버팅
-                    }
-                    target {
-                        packageName = 'com.getinline.getinline'
-                        directory = generatedJooq
-                    }
-                    strategy.name = "org.jooq.codegen.DefaultGeneratorStrategy"
-                }
-            }
-        }
-    }
-}
+//def generatedJooq = 'src/main/generated-jooq'
+//jooq {
+//    // use jOOQ version defined in Spring Boot
+////    version = dependencyManagement.importedProperties['jooq.version']
+//    version = project.jooqVersion
+//
+//    configurations {
+//        main {
+//            generationTool {
+//                logging = org.jooq.meta.jaxb.Logging.WARN
+//                jdbc {
+//                    driver = 'com.mysql.cj.jdbc.Driver'
+//                    url = 'jdbc:mysql://172.17.37.139:3306/mygetinline?useSSL=false&allowPublicKeyRetrieval=true'
+//                    user = 'strou73'
+//                    password = '1234'
+//                }
+//                generator {
+//                    name = 'org.jooq.codegen.JavaGenerator'
+//                    database{
+//                        name = 'org.jooq.meta.mysql.MySQLDatabase'
+//                        inputSchema = 'mygetinline'
+//                        includes = '.*'
+//                        excludes = ''
+//                        forcedTypes {
+//                            forcedType {
+//                                userType = 'com.getinline.getinline.constant.EventStatus'
+//                                enumConverter = true
+//                                includeExpression = '.*\\.event_status'
+//                                includeTypes = '.*'
+//                            }
+//                            forcedType {
+//                                userType = 'com.getinline.getinline.constant.PlaceType'
+//                                enumConverter = true
+//                                includeExpression = '.*\\.place_type'
+//                                includeTypes = '.*'
+//                            }
+//                        }
+//                    }
+//                    generate {
+//                        deprecated = false
+//                        records = true
+//                        immutablePojos = true
+//                        fluentSetters = true
+//                        javaTimeTypes = true // LocalDateTime 을 자동으로 컨버팅
+//                    }
+//                    target {
+//                        packageName = 'com.getinline.getinline'
+//                        directory = generatedJooq
+//                    }
+//                    strategy.name = "org.jooq.codegen.DefaultGeneratorStrategy"
+//                }
+//            }
+//        }
+//    }
+//}
 
 // incremental build (증분 빌드) - Jooq 오브젝트 생성 퍼포먼스 향상: 변경점만 적용
-tasks.named('generateJooq').configure {
-    allInputsDeclared = true
-    outputs.cacheIf{true}
-}
+//tasks.named('generateJooq').configure {
+//    allInputsDeclared = true
+//    outputs.cacheIf{true}
+//}
+
+// Source 가 잘 적용되지 않을시에 강제 적용
+//sourceSets {
+//    main.java.srcDir generatedJooq
+//}

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@
 plugins {
     id 'org.springframework.boot' version '2.7.1'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'nu.studer.jooq' version '5.2.2' //6.0.1 은 jooq 버전이 3.15.1 스프링부트에서 자동관리해주는 버전보다 높다.
     id 'java'
     id 'war'
 }
@@ -29,6 +30,12 @@ repositories {
     mavenCentral()
 }
 
+project.ext {
+    querydslVersion = dependencyManagement.importedProperties['querydsl.version']
+    jooqVersion = dependencyManagement.importedProperties['jooq.version']
+    mysqlVersion = dependencyManagement.importedProperties['mysql.version']
+}
+
 dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -45,17 +52,21 @@ dependencies {
     implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     // https://mvnrepository.com/artifact/org.hibernate.javax.persistence/hibernate-jpa-2.1-api
     implementation group: 'org.hibernate.javax.persistence', name: 'hibernate-jpa-2.1-api', version: '1.0.0.Final'
-    runtimeOnly 'mysql:mysql-connector-java:8.0.30'
+    runtimeOnly 'mysql:mysql-connector-java'
 //    runtimeOnly 'org.postgresql:postgresql'
 
 
 
-    // queryDSL 설정
+    // queryDSL 설정 https://start.spring.io/
     implementation "com.querydsl:querydsl-jpa"
     implementation "com.querydsl:querydsl-collections"
     annotationProcessor("jakarta.persistence:jakarta.persistence-api") // java.lang.NoClassDefFoundError(javax.annotation.Entity) 발생 대응
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa" // querydsl JPAAnnotationProcessor 사용 지정
     annotationProcessor "jakarta.annotation:jakarta.annotation-api" // java.lang.NoClassDefFoundError (javax.annotation.Generated) 발생 대응
+
+    // Jooq 설정 https://start.spring.io/
+    implementation 'org.springframework.boot:spring-boot-starter-jooq'
+    jooqGenerator "mysql:mysql-connector-java:${project.mysqlVersion}"
 }
 
 tasks.named('test') {
@@ -86,3 +97,66 @@ tasks.withType(JavaCompile) {
 //        attributes('Main-Class': 'com.uno.getinline.GetInLineApplication')
 //    }
 //}
+
+
+def generatedJooq = 'src/main/generated-jooq'
+jooq {
+    // use jOOQ version defined in Spring Boot
+//    version = dependencyManagement.importedProperties['jooq.version']
+    version = project.jooqVersion
+
+    configurations {
+        main {
+            generationTool {
+                logging = org.jooq.meta.jaxb.Logging.WARN
+                jdbc {
+                    driver = 'com.mysql.cj.jdbc.Driver'
+                    url = 'jdbc:mysql://172.17.47.198:3306/mygetinline?useSSL=false&allowPublicKeyRetrieval=true'
+                    user = 'strou73'
+                    password = '1234'
+                }
+                generator {
+                    name = 'org.jooq.codegen.JavaGenerator'
+                    database{
+                        name = 'org.jooq.meta.mysql.MySQLDatabase'
+                        inputSchema = 'mygetinline'
+                        includes = '.*'
+                        excludes = ''
+                        forcedTypes {
+                            forcedType {
+                                userType = 'com.getinline.getinline.constant.EventStatus'
+                                enumConverter = true
+                                includeExpression = '.*\\.event_status'
+                                includeTypes = '.*'
+                            }
+                            forcedType {
+                                userType = 'com.getinline.getinline.constant.PlaceType'
+                                enumConverter = true
+                                includeExpression = '.*\\.place_type'
+                                includeTypes = '.*'
+                            }
+                        }
+                    }
+                    generate {
+                        deprecated = false
+                        records = true
+                        immutablePojos = true
+                        fluentSetters = true
+                        javaTimeTypes = true // LocalDateTime 을 자동으로 컨버팅
+                    }
+                    target {
+                        packageName = 'com.getinline.getinline'
+                        directory = generatedJooq
+                    }
+                    strategy.name = "org.jooq.codegen.DefaultGeneratorStrategy"
+                }
+            }
+        }
+    }
+}
+
+// incremental build (증분 빌드) - Jooq 오브젝트 생성 퍼포먼스 향상: 변경점만 적용
+tasks.named('generateJooq').configure {
+    allInputsDeclared = true
+    outputs.cacheIf{true}
+}

--- a/src/main/java/com/getinline/getinline/config/JooqConfig.java
+++ b/src/main/java/com/getinline/getinline/config/JooqConfig.java
@@ -1,54 +1,54 @@
-package com.getinline.getinline.config;
-
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.jooq.ConnectionProvider;
-import org.jooq.ExecuteListenerProvider;
-import org.jooq.conf.Settings;
-import org.jooq.impl.DefaultConfiguration;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.jooq.DefaultConfigurationCustomizer;
-import org.springframework.boot.autoconfigure.jooq.JooqProperties;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
-import javax.sql.DataSource;
-
-// @EnableConfigurationProperties 뭔지 공부하기
-@EnableConfigurationProperties(JooqProperties.class)
-@Configuration
-public class JooqConfig {
-
-    @Bean
-    @ConditionalOnMissingBean(org.jooq.Configuration.class)
-    public DefaultConfiguration jooqConfiguration(CustomJooqProperties cumstomJooqProperties, JooqProperties properties, ConnectionProvider connectionProvider,
-                                                  DataSource dataSource, ObjectProvider<ExecuteListenerProvider> executeListenerProviders,
-                                                  ObjectProvider<DefaultConfigurationCustomizer> configurationCustomizers) {
-        DefaultConfiguration configuration = new DefaultConfiguration();
-        configuration.set(properties.determineSqlDialect(dataSource));
-        configuration.set(connectionProvider);
-        configuration.set(executeListenerProviders.orderedStream().toArray(ExecuteListenerProvider[]::new));
-        // 포멧설정 추가
-        configuration.setSettings(new Settings().withRenderFormatted(cumstomJooqProperties.isFormatSql()));
-        configurationCustomizers.orderedStream().forEach((customizer) -> customizer.customize(configuration));
-        return configuration;
-    }
-
-    /*
-        이 값을 통해서 sql 문장을 이쁘게 포맷해준다.
-     */
-    @Getter
-    @RequiredArgsConstructor
-    @ConstructorBinding
-    @ConfigurationProperties("spring.custom-jooq")
-    public static class CustomJooqProperties {
-        /**
-         * sql pretty formatting
-         */
-        private final boolean formatSql;
-    }
-}
+//package com.getinline.getinline.config;
+//
+//import lombok.Getter;
+//import lombok.RequiredArgsConstructor;
+//import org.jooq.ConnectionProvider;
+//import org.jooq.ExecuteListenerProvider;
+//import org.jooq.conf.Settings;
+//import org.jooq.impl.DefaultConfiguration;
+//import org.springframework.beans.factory.ObjectProvider;
+//import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+//import org.springframework.boot.autoconfigure.jooq.DefaultConfigurationCustomizer;
+//import org.springframework.boot.autoconfigure.jooq.JooqProperties;
+//import org.springframework.boot.context.properties.ConfigurationProperties;
+//import org.springframework.boot.context.properties.ConstructorBinding;
+//import org.springframework.boot.context.properties.EnableConfigurationProperties;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//
+//import javax.sql.DataSource;
+//
+//// @EnableConfigurationProperties 뭔지 공부하기
+//@EnableConfigurationProperties(JooqProperties.class)
+//@Configuration
+//public class JooqConfig {
+//
+//    @Bean
+//    @ConditionalOnMissingBean(org.jooq.Configuration.class)
+//    public DefaultConfiguration jooqConfiguration(CustomJooqProperties cumstomJooqProperties, JooqProperties properties, ConnectionProvider connectionProvider,
+//                                                  DataSource dataSource, ObjectProvider<ExecuteListenerProvider> executeListenerProviders,
+//                                                  ObjectProvider<DefaultConfigurationCustomizer> configurationCustomizers) {
+//        DefaultConfiguration configuration = new DefaultConfiguration();
+//        configuration.set(properties.determineSqlDialect(dataSource));
+//        configuration.set(connectionProvider);
+//        configuration.set(executeListenerProviders.orderedStream().toArray(ExecuteListenerProvider[]::new));
+//        // 포멧설정 추가
+//        configuration.setSettings(new Settings().withRenderFormatted(cumstomJooqProperties.isFormatSql()));
+//        configurationCustomizers.orderedStream().forEach((customizer) -> customizer.customize(configuration));
+//        return configuration;
+//    }
+//
+//    /*
+//        이 값을 통해서 sql 문장을 이쁘게 포맷해준다.
+//     */
+//    @Getter
+//    @RequiredArgsConstructor
+//    @ConstructorBinding
+//    @ConfigurationProperties("spring.custom-jooq")
+//    public static class CustomJooqProperties {
+//        /**
+//         * sql pretty formatting
+//         */
+//        private final boolean formatSql;
+//    }
+//}

--- a/src/main/java/com/getinline/getinline/config/JooqConfig.java
+++ b/src/main/java/com/getinline/getinline/config/JooqConfig.java
@@ -1,0 +1,54 @@
+package com.getinline.getinline.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.jooq.ConnectionProvider;
+import org.jooq.ExecuteListenerProvider;
+import org.jooq.conf.Settings;
+import org.jooq.impl.DefaultConfiguration;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.jooq.DefaultConfigurationCustomizer;
+import org.springframework.boot.autoconfigure.jooq.JooqProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+// @EnableConfigurationProperties 뭔지 공부하기
+@EnableConfigurationProperties(JooqProperties.class)
+@Configuration
+public class JooqConfig {
+
+    @Bean
+    @ConditionalOnMissingBean(org.jooq.Configuration.class)
+    public DefaultConfiguration jooqConfiguration(CustomJooqProperties cumstomJooqProperties, JooqProperties properties, ConnectionProvider connectionProvider,
+                                                  DataSource dataSource, ObjectProvider<ExecuteListenerProvider> executeListenerProviders,
+                                                  ObjectProvider<DefaultConfigurationCustomizer> configurationCustomizers) {
+        DefaultConfiguration configuration = new DefaultConfiguration();
+        configuration.set(properties.determineSqlDialect(dataSource));
+        configuration.set(connectionProvider);
+        configuration.set(executeListenerProviders.orderedStream().toArray(ExecuteListenerProvider[]::new));
+        // 포멧설정 추가
+        configuration.setSettings(new Settings().withRenderFormatted(cumstomJooqProperties.isFormatSql()));
+        configurationCustomizers.orderedStream().forEach((customizer) -> customizer.customize(configuration));
+        return configuration;
+    }
+
+    /*
+        이 값을 통해서 sql 문장을 이쁘게 포맷해준다.
+     */
+    @Getter
+    @RequiredArgsConstructor
+    @ConstructorBinding
+    @ConfigurationProperties("spring.custom-jooq")
+    public static class CustomJooqProperties {
+        /**
+         * sql pretty formatting
+         */
+        private final boolean formatSql;
+    }
+}

--- a/src/main/java/com/getinline/getinline/repository/jooq/EventRepositoryJooq.java
+++ b/src/main/java/com/getinline/getinline/repository/jooq/EventRepositoryJooq.java
@@ -1,19 +1,19 @@
-package com.getinline.getinline.repository.jooq;
-
-import com.getinline.getinline.constant.EventStatus;
-import com.getinline.getinline.dto.EventViewResponse;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-
-import java.time.LocalDateTime;
-
-public interface EventRepositoryJooq {
-    Page<EventViewResponse> findEventViewPageBySearchParams(
-            String placeName,
-            String eventName,
-            EventStatus eventStatus,
-            LocalDateTime eventStartDatetime,
-            LocalDateTime eventEndDatetime,
-            Pageable pageable
-    );
-}
+//package com.getinline.getinline.repository.jooq;
+//
+//import com.getinline.getinline.constant.EventStatus;
+//import com.getinline.getinline.dto.EventViewResponse;
+//import org.springframework.data.domain.Page;
+//import org.springframework.data.domain.Pageable;
+//
+//import java.time.LocalDateTime;
+//
+//public interface EventRepositoryJooq {
+//    Page<EventViewResponse> findEventViewPageBySearchParams(
+//            String placeName,
+//            String eventName,
+//            EventStatus eventStatus,
+//            LocalDateTime eventStartDatetime,
+//            LocalDateTime eventEndDatetime,
+//            Pageable pageable
+//    );
+//}

--- a/src/main/java/com/getinline/getinline/repository/jooq/EventRepositoryJooq.java
+++ b/src/main/java/com/getinline/getinline/repository/jooq/EventRepositoryJooq.java
@@ -1,0 +1,19 @@
+package com.getinline.getinline.repository.jooq;
+
+import com.getinline.getinline.constant.EventStatus;
+import com.getinline.getinline.dto.EventViewResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+
+public interface EventRepositoryJooq {
+    Page<EventViewResponse> findEventViewPageBySearchParams(
+            String placeName,
+            String eventName,
+            EventStatus eventStatus,
+            LocalDateTime eventStartDatetime,
+            LocalDateTime eventEndDatetime,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/getinline/getinline/repository/jooq/EventRepositoryJooqImpl.java
+++ b/src/main/java/com/getinline/getinline/repository/jooq/EventRepositoryJooqImpl.java
@@ -1,19 +1,88 @@
-package com.getinline.getinline.repository.jooq;
-
-import com.getinline.getinline.constant.EventStatus;
-import com.getinline.getinline.dto.EventViewResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
-
-import java.time.LocalDateTime;
-
-@RequiredArgsConstructor
-@Repository
-public class EventRepositoryJooqImpl implements EventRepositoryJooq{
-    @Override
-    public Page<EventViewResponse> findEventViewPageBySearchParams(String placeName, String eventName, EventStatus eventStatus, LocalDateTime eventStartDatetime, LocalDateTime eventEndDatetime, Pageable pageable) {
-        return null;
-    }
-}
+//package com.getinline.getinline.repository.jooq;
+//
+//import com.getinline.getinline.constant.EventStatus;
+//import com.getinline.getinline.dto.EventViewResponse;
+//import com.getinline.getinline.tables.Event;
+//import com.getinline.getinline.tables.Place;
+//import lombok.RequiredArgsConstructor;
+//import org.jooq.Condition;
+//import org.jooq.DSLContext;
+//import org.jooq.SelectField;
+//import org.springframework.data.domain.Page;
+//import org.springframework.data.domain.PageImpl;
+//import org.springframework.data.domain.Pageable;
+//import org.springframework.stereotype.Repository;
+//
+//import java.time.LocalDateTime;
+//import java.util.List;
+//
+//import static org.jooq.impl.DSL.trueCondition;
+//
+//@RequiredArgsConstructor
+//@Repository
+//public class EventRepositoryJooqImpl implements EventRepositoryJooq{
+//
+//    private final DSLContext dslContext;
+//
+//    @Override
+//    public Page<EventViewResponse> findEventViewPageBySearchParams(
+//            String placeName,
+//            String eventName,
+//            EventStatus eventStatus,
+//            LocalDateTime eventStartDatetime,
+//            LocalDateTime eventEndDatetime,
+//            Pageable pageable
+//    ) {
+//        final Event event = Event.EVENT;
+//        final Place place = Place.PLACE;
+//
+//        Condition condition = trueCondition();
+//
+//        SelectField<?>[] select = {
+//            event.ID,
+//            place.PLACE_NAME,
+//            event.EVENT_NAME,
+//            event.EVENT_STATUS,
+//            event.EVENT_START_DATETIME,
+//            event.EVENT_END_DATETIME,
+//            event.CURRENT_NUMBER_OF_PEOPLE,
+//            event.CAPACITY,
+//            event.MEMO
+//        };
+//
+//        if (placeName != null && !placeName.isBlank()){
+//            condition = condition.and(place.PLACE_NAME.containsIgnoreCase(placeName));
+//        }
+//        if (eventName != null && !eventName.isBlank()){
+//            condition = condition.and(event.EVENT_NAME.containsIgnoreCase(eventName));
+//        }
+//        if (eventStatus != null){
+//            condition = condition.and(event.EVENT_STATUS.containsIgnoreCase(eventStatus));
+//        }
+//        if (eventStartDatetime != null){
+//            condition = condition.and(event.EVENT_START_DATETIME.greaterOrEqual(eventStartDatetime));
+//        }
+//        if (eventEndDatetime != null){
+//            condition = condition.and(event.EVENT_END_DATETIME.lessOrEqual(eventEndDatetime));
+//        }
+//
+//        int count = dslContext
+//                .selectCount()
+//                .from(event)
+//                .innerJoin(place)
+//                .onKey()
+//                .where(condition)
+//                .fetchSingleInto(int.class);
+//
+//        List<EventViewResponse> pagedList = dslContext
+//                .select(select)
+//                .from(event)
+//                .innerJoin(place)
+//                .onKey()
+//                .where(condition)
+//                .limit(pageable.getOffset(), pageable.getPageSize())
+//                .fetchInto(EventViewResponse.class);
+//
+//        return new PageImpl<>(pagedList, pageable, count);
+//    }
+//}

--- a/src/main/java/com/getinline/getinline/repository/jooq/EventRepositoryJooqImpl.java
+++ b/src/main/java/com/getinline/getinline/repository/jooq/EventRepositoryJooqImpl.java
@@ -1,0 +1,19 @@
+package com.getinline.getinline.repository.jooq;
+
+import com.getinline.getinline.constant.EventStatus;
+import com.getinline.getinline.dto.EventViewResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Repository
+public class EventRepositoryJooqImpl implements EventRepositoryJooq{
+    @Override
+    public Page<EventViewResponse> findEventViewPageBySearchParams(String placeName, String eventName, EventStatus eventStatus, LocalDateTime eventStartDatetime, LocalDateTime eventEndDatetime, Pageable pageable) {
+        return null;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@ logging.level.org.springframework.web.servlet=debug
 # 로그에서 hibernate 가 작성하는 쿼리문을 보는것(bindingParameter 가 ??? 나오는것을 볼 수 있게 해준다.)
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=trace
 
-# Database
+################################### Database #############################################################
 # 스프링부트 2.5 부터는 database 를 inmemory 에 테이블을 만들고 셋팅하려면 initialization 를 true 로 설정해주어야 한다.
 spring.jpa.defer-datasource-initialization=true
 # Entity 정보를 읽어 테이블을 만든다. h2=> create-dtop, mysql=> create, 배포 => none
@@ -24,7 +24,7 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.h2.console.enabled=false
 # 테스트 db 로 사용하는 방법
 #spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.url=jdbc:mysql://172.17.41.18:3306/mygetinline?useSSL=false&allowPublicKeyRetrieval=true
+spring.datasource.url=jdbc:mysql://172.17.47.198:3306/mygetinline?useSSL=false&allowPublicKeyRetrieval=true
 spring.datasource.username=strou73
 spring.datasource.password=1234
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
@@ -35,7 +35,13 @@ spring.datasource.tomcat.testOnBorrow=true
 
 spring.datasource.tomcat.validationQuery=SELECT 1
 spring.jpa.properties.hibernate.default_batch_fetch_size=100
-# API
+
+# CustomJooq 를 만들었고 그 안에 sql 문을 이쁘게 포맷하는 기능을 properties 파일을 통해 조절해준다.
+# 커스텀 파일 생성전에는 이걸 넣을수가 없다. annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+# 어노테이션 프로세서는 공부가 확실히 필요할듯하다.
+spring.custom-jooq.format-sql=true
+
+############################################# API ###############################################
 spring.data.rest.base-path=/api
 #spring.data.rest.detection-strategy=annotated
 
@@ -45,7 +51,7 @@ spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
 spring.main.banner-mode=off
 
-# View
+########################################## View ###################################################
 spring.thymeleaf.cache=false
 spring.thymeleaf3.decoupled-logic=true
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,7 @@ spring.jpa.defer-datasource-initialization=true
 #spring.jpa.properties.hibernate.default_batch_fetch_size=100
 
 #spring.jpa.hibernate.ddl-auto=create-drop
+###### ddl-auto=create 를 Jooq 를 사용할때에는 none 으로 둬야한다. querydsl, jooq 동시 사용하면 충돌발생
 spring.jpa.hibernate.ddl-auto=create
 # log에 sql 문장 표출
 spring.jpa.show-sql=true
@@ -24,11 +25,11 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.h2.console.enabled=false
 # 테스트 db 로 사용하는 방법
 #spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.url=jdbc:mysql://172.17.47.198:3306/mygetinline?useSSL=false&allowPublicKeyRetrieval=true
+spring.datasource.url=jdbc:mysql://172.17.37.139:3306/mygetinline?useSSL=false&allowPublicKeyRetrieval=true
 spring.datasource.username=strou73
 spring.datasource.password=1234
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-# data.sql 을 반영할 수 있다.
+# data.sql 을 반영할 수 있다(always). 추가로 Jooq 사용시 never 로 변경해야한다. 자동 스크립트 적용 X
 spring.sql.init.mode=always
 
 spring.datasource.tomcat.testOnBorrow=true

--- a/src/test/java/com/getinline/getinline/repository/jooq/EventRepositoryJooqImplTest.java
+++ b/src/test/java/com/getinline/getinline/repository/jooq/EventRepositoryJooqImplTest.java
@@ -1,0 +1,115 @@
+//package com.getinline.getinline.repository.jooq;
+//
+//import com.getinline.getinline.config.JooqConfig;
+//import com.getinline.getinline.constant.EventStatus;
+//import com.getinline.getinline.dto.EventViewResponse;
+//import org.assertj.core.api.Assertions;
+//import org.assertj.core.api.AssertionsForClassTypes;
+//import org.jooq.DSLContext;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.context.properties.EnableConfigurationProperties;
+//import org.springframework.boot.test.autoconfigure.jooq.JooqTest;
+//import org.springframework.context.annotation.Import;
+//import org.springframework.data.domain.Page;
+//import org.springframework.data.domain.PageRequest;
+//import org.springframework.data.domain.Sort;
+//
+//import java.time.LocalDateTime;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//
+//@DisplayName("DB - 이벤트 (Jooq)")
+//@Import({EventRepositoryJooqImpl.class, JooqConfig.class})
+//@EnableConfigurationProperties(JooqConfig.CustomJooqProperties.class)
+//@JooqTest
+//class EventRepositoryJooqImplTest {
+//
+//    /*
+//        @JooqTest
+//        @JooqTest 는 dslContext 를 @Autowired 받는것이 주 관심사이고,
+//        나머지 AutoConfig 들은 모두 꺼버린다. 그렇기에 수동으로 @Import 를 직접 해주어야한다.
+//     */
+//    private final DSLContext dslContext; // 원래 @JooqTest 의 관심사, 현재 여기서는 사용안한다.
+//    private final EventRepositoryJooq sut;
+//
+//
+//    public EventRepositoryJooqImplTest(
+//            @Autowired DSLContext dslContext, // @JooqTest 는 dslContext 를 @Autowired 받는것
+//            @Autowired EventRepositoryJooq sut
+//    ) {
+//        this.dslContext = dslContext;
+//        this.sut = sut;
+//    }
+//
+//    @DisplayName("이벤트 뷰 데이터를 검색 파리미터와 함께 조회하면, 조건에 맞는 데이터를 페이징 처리하여 리턴한다.")
+//    @Test
+//    void givenSearchParams_whenFindingEventViewPage_thenReturnsEventViewResponsePage(){
+//        // Given
+//
+//
+//        // When
+//        Page<EventViewResponse> eventPage = sut.findEventViewPageBySearchParams(
+//                "배드민턴",
+//                "운동1",
+//                EventStatus.OPENED,
+//                LocalDateTime.of(2021,1,1,0,0,0),
+//                LocalDateTime.of(2021,1,2,0,0,0),
+//                PageRequest.of(0,5)
+//        );
+//
+//        // Then
+//        AssertionsForClassTypes.assertThat(eventPage.getTotalPages()).isEqualTo(1);
+//        AssertionsForClassTypes.assertThat(eventPage.getNumberOfElements()).isEqualTo(1);
+//        AssertionsForClassTypes.assertThat(eventPage.getTotalElements()).isEqualTo(1);
+//        AssertionsForClassTypes.assertThat(eventPage.getContent().get(0))
+//                .hasFieldOrPropertyWithValue("placeName", "서울 배드민턴장")
+//                .hasFieldOrPropertyWithValue("eventName", "운동1")
+//                .hasFieldOrPropertyWithValue("eventStatus", EventStatus.OPENED)
+//                .hasFieldOrPropertyWithValue("eventStartDatetime", LocalDateTime.of(2021,1,1,9,0,0))
+//                .hasFieldOrPropertyWithValue("eventEndDatetime", LocalDateTime.of(2021,1,1,12,0,0));
+//    }
+//
+//    @DisplayName("이벤트 뷰 데이터 검색어에 따른 조회 결과가 없으면, 빈 데이터를 페이징 정보와 함께 리턴한다.")
+//    @Test
+//    void givenSearchParams_whenFindingNonexistentEventViewPage_thenReturnsEmptyEventViewResponsePage() {
+//        // Given
+//
+//        // When
+//        Page<EventViewResponse> eventPage = sut.findEventViewPageBySearchParams(
+//                "없은 장소",
+//                "없는 이벤트",
+//                null,
+//                LocalDateTime.of(1000, 1, 1, 1, 1, 1),
+//                LocalDateTime.of(1000, 1, 1, 1, 1, 0),
+//                PageRequest.of(0, 5)
+//        );
+//
+//        // Then
+//        assertThat(eventPage.getTotalPages()).isEqualTo(0);
+//        assertThat(eventPage.getNumberOfElements()).isEqualTo(0);
+//        assertThat(eventPage.getTotalElements()).isEqualTo(0);
+//    }
+//
+//    @DisplayName("이벤트 뷰 데이터를 검색 파라미터 없이 페이징 값만 주고 조회하면, 전체 데이터를 페이징 처리하여 리턴한다.")
+//    @Test
+//    void givenPagingInfoOnly_whenFindingEventViewPage_thenReturnsEventViewResponsePage() {
+//        // Given
+//
+//        // When
+//        Page<EventViewResponse> eventPage = sut.findEventViewPageBySearchParams(
+//                null,
+//                null,
+//                null,
+//                null,
+//                null,
+//                PageRequest.of(0, 5, Sort.by(Sort.Order.asc("placeName"), Sort.Order.desc("eventName")))
+//        );
+//
+//        // Then
+//        assertThat(eventPage.getTotalPages()).isEqualTo(6);
+//        assertThat(eventPage.getNumberOfElements()).isEqualTo(5);
+//        assertThat(eventPage.getTotalElements()).isEqualTo(26);
+//    }
+//}

--- a/src/test/text/Part4. Spring Data JPA/복잡한 쿼리의 작성과 응용 ch3/03.jooq 활용 (1)
+++ b/src/test/text/Part4. Spring Data JPA/복잡한 쿼리의 작성과 응용 ch3/03.jooq 활용 (1)
@@ -1,0 +1,91 @@
+* jooq 활용 (1)
+
+    - Jooq
+      테이블 스키마로부터 자바 코드를 만들어주는 라이브러리
+      - 시스템의 설계가 자바 코드(엔티티)가 아닌, DB 에서 시작될 때 유용한 구조
+
+    * Build Gradle 설정
+
+          plugins {
+              /*
+                6.0.1 은 jooq 버전이 3.15.1 스프링부트에서 자동관리해주는 버전보다 높다.
+                5.2.2 사용 권장. 수동설정으로 버전을 맞춰주면 상관없다.
+              */
+              id 'nu.studer.jooq' version '5.2.2'
+          }
+
+          - 버전 자동관리 설정. 변수에 스프링에서 자동으로 설정해준 버전을 넣어준다.
+          project.ext {
+              querydslVersion = dependencyManagement.importedProperties['querydsl.version']
+              jooqVersion = dependencyManagement.importedProperties['jooq.version']
+              mysqlVersion = dependencyManagement.importedProperties['mysql.version']
+          }
+
+          - Jooq 설정 https://start.spring.io/
+          implementation 'org.springframework.boot:spring-boot-starter-jooq'
+          jooqGenerator "mysql:mysql-connector-java:${project.mysqlVersion}"
+
+          - GeneratedJooq 파일 생성 위치 설정
+          def generatedJooq = 'src/main/generated-jooq'
+
+          - Jooq 세부설정
+          jooq {
+              // use jOOQ version defined in Spring Boot
+              // version = dependencyManagement.importedProperties['jooq.version']
+              version = project.jooqVersion
+
+              configurations {
+                  main {
+                      generationTool {
+                          logging = org.jooq.meta.jaxb.Logging.WARN
+                          jdbc {
+                              driver = 'com.mysql.cj.jdbc.Driver'
+                              url = 'jdbc:mysql://172.17.47.198:3306/mygetinline?useSSL=false&allowPublicKeyRetrieval=true'
+                              user = 'strou73'
+                              password = '1234'
+                          }
+                          generator {
+                              name = 'org.jooq.codegen.JavaGenerator'
+                              database{
+                                  name = 'org.jooq.meta.mysql.MySQLDatabase'
+                                  inputSchema = 'mygetinline'
+                                  includes = '.*'
+                                  excludes = ''
+                                  forcedTypes {
+                                      forcedType {
+                                          userType = 'com.getinline.getinline.constant.EventStatus'
+                                          enumConverter = true
+                                          includeExpression = '.*\\.event_status'
+                                          includeTypes = '.*'
+                                      }
+                                      forcedType {
+                                          userType = 'com.getinline.getinline.constant.PlaceType'
+                                          enumConverter = true
+                                          includeExpression = '.*\\.place_type'
+                                          includeTypes = '.*'
+                                      }
+                                  }
+                              }
+                              generate {
+                                  deprecated = false
+                                  records = true
+                                  immutablePojos = true
+                                  fluentSetters = true
+                                  javaTimeTypes = true // LocalDateTime 을 자동으로 컨버팅
+                              }
+                              target {
+                                  packageName = 'com.getinline.getinline'
+                                  directory = generatedJooq
+                              }
+                              strategy.name = "org.jooq.codegen.DefaultGeneratorStrategy"
+                          }
+                      }
+                  }
+              }
+          }
+
+          - incremental build (증분 빌드) - Jooq 오브젝트 생성 퍼포먼스 향상: 변경점만 적용
+          tasks.named('generateJooq').configure {
+              allInputsDeclared = true
+              outputs.cacheIf{true}
+          }

--- a/src/test/text/Part4. Spring Data JPA/복잡한 쿼리의 작성과 응용 ch3/03.jooq 활용 (2)
+++ b/src/test/text/Part4. Spring Data JPA/복잡한 쿼리의 작성과 응용 ch3/03.jooq 활용 (2)
@@ -1,0 +1,31 @@
+* jooq 활용 (2)
+
+  * Jooq, 좋은 이유
+    - Jooq 방식으로 사용한다면, 엔티티를 작성할 필요가 없다. (데이터베이스 스키마를 잘 만들어두면 된다)
+    - 로그가 보기 예쁘다
+        1.query 로그 안에 binding parameter 가 함께 포함됨
+        2.결과 로그가 예쁘다.
+
+
+  * Jooq, 불편한 이유
+    ORM 기술이 아니기 때문에, Spring Data JPA 와 결이 잘 안 맞음
+    - JPA 와 정반대의 매커니즘: Jooq 클래스가 엔티티 클래스를 방해
+    - JPA 기술이 아니어서 오는 문제점
+        1. Spring Data JPA 트랜잭션 연동이 힘듬: 자체 트랜잭션 기술 -> Jooq 코드가 서비스에 노출
+          기능이 준비되어있긴하다. 그러나 직접 서비스에서 주크 코드를 노출시켜야한다(작성해야함).
+        2. 하이버네이트 auto-ddl 사용 불가, DB 스키마는 이미 준비되어 있어야 함
+    - 스프링과 연동되어있지 않아서 오는 불편함
+        1. 스프링 Pageable 정보로부터 Jooq 쿼리를 조립하기가 상당히 까다로움
+    - gradle 플러그인을 쓸 경우, DB 정보가 build.gradle 에 침투함(build.gradle 에 DB 정보 작성.)
+        1. DB 기본 정보, 로깅, 타입 변환(enum 등) 정보, 패키지 정보, DB dialect, JDBC 드라이버 정보...
+    - 그리고 매뉴얼도 꽤 어려움.. 레퍼런스도 적고.
+
+
+
+  * 스프링이 초기에 밀어줬지만 Querydsl 에 밀리는 또 하나의 이유
+    유료.
+    - Open Source 플랜만 무료
+      - open source DB dialect 지원: derby, firebird, h2, hsqldb, ignite, mariadb, mysql,
+        postgresql, sqlite
+      - 지원 안되는 대표적인 DB: ms access, oracle, sql server, aurora, bigquery, db2, snowflake 등
+    - Express, Professional, Enterprise 플랜에 따라 단계별 과금


### PR DESCRIPTION
Jooq 활용 (1), (2) 마무리
Jooq는 실제 실무에서는 거의 사용되지 않는다고 한다.
1.querydsl 의 비중이 많이 높으며, Jooq는 ORM 기술이 아니기 때문에 SpringDataJPA 와 결이 잘 맞지 않는다.
2.하이버네이트 auto-ddl 또한 사용이 불가능하다. DB 스키마는 미리 준비되어있어야 한다.
3.gradle 플러그인 사용시 builder.gradle에 DB설정 정보를 작성한다. (DB 정보가 build.gradle에 침투한다)
4.메뉴얼이 어렵다. 레퍼런스도 적다.
5.open source 플랜은 무료인반면 나머지는 유로이다.