### PR TITLE
Add #27 순환 참조 문제

### DIFF
--- a/src/test/text/Part4. Spring Data JPA/복잡한 쿼리의 작성과 응용 ch3/05.순환 참조 문제
+++ b/src/test/text/Part4. Spring Data JPA/복잡한 쿼리의 작성과 응용 ch3/05.순환 참조 문제
@@ -1,0 +1,43 @@
+* 순환 참조 문제
+
+    - 순환 참조 문제란?
+      이벤트 & 장소가 있다. 이벤트가 장소의 이름을 알려달라하고
+      장소는 이벤트의 정보를 보여달라 하는것이다. 서로 서로를 계속 알려주며
+      StackOverFlow 가 일어난다.
+
+      각 모듈이 서로를 의존하고 있는 상태
+      스프링을 사용하다보면, JPA 뿐만 아니라 다양한 위치에서 간혹 경험하게 된다.
+      - 스프링 컴포넌트끼리 참조하는 경우
+      - JPA 에서 가장 흔하게 발생하는 순환 참조: ToString() (lombok)
+
+      해결방법: 서로가 서로를 참조하는것이기에 한쪽의 참조를 끊어주면 된다.
+
+
+
+    - 순환 참조 만들기 (JpaConfig 와 ThymeleafConfig 가 서로를 참조하게 만든다)
+
+      @RequiredArgsConstructor
+      @EnableJpaAuditing
+      @Component
+      public class JpaConfig {
+        private final ThymeleafConfig thymeleafConfig;
+      }
+
+
+      @RequiredArgsConstructor
+      @Configuration
+      public class ThymeleafConfig {
+        private final JpaConfig jpaConfig;
+      }
+
+      참 친절하게도 스프링부트는 2버전대 이상부터는 순환참조도 로그로 알려준다.
+      The dependencies of some of the beans in the application context form a cycle:
+        jpaConfig defined in file ......
+        thymeleafConfig defined in file....
+
+
+    - lombok 의 ToString() 으로 인한 순환참조시
+      @ToString.Exclude 를 사용한다.
+
+      @ToString.Exclude
+      .... getPlace();


### PR DESCRIPTION
순환 참조는 서로가 서로를 참조해서 계속해서 참조가 일어나 발생되는 문제이다.

Place의 ToString() 이 Event를 참조하고 Event의 ToString()이 Place를 참조하고 다시 또 Place가 .... 이 무한 반복된다. 그 결과 StackOverFlow가 일어난다.